### PR TITLE
Add listening address configuration in XML file

### DIFF
--- a/bundles/commons/src/main/java/org/jscsi/parser/login/ISID.java
+++ b/bundles/commons/src/main/java/org/jscsi/parser/login/ISID.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2012, University of Konstanz, Distributed Systems Group All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
  * following conditions are met: * Redistributions of source code must retain the above copyright notice, this list of
  * conditions and the following disclaimer. * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation and/or other materials provided with the
  * distribution. * Neither the name of the University of Konstanz nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
@@ -147,7 +147,7 @@ import org.jscsi.utils.Utils;
  * it is installed (see Section 9.1.1 Conservative Reuse of ISIDs and Section 9.1.2 iSCSI Name, ISID, and TPGT Use). The
  * resultant ISID MUST also be persistent over power cycles, reboot, card swap, etc. For details have a look in the
  * [RFC3721].
- * 
+ *
  * @author Volker Wildi
  */
 public final class ISID {
@@ -186,7 +186,7 @@ public final class ISID {
 
         /**
          * Returns the value of this enumeration.
-         * 
+         *
          * @return The value of this enumeration.
          */
         public final byte value () {
@@ -196,7 +196,7 @@ public final class ISID {
 
         /**
          * Returns the constant defined for the given <code>value</code>.
-         * 
+         *
          * @param value The value to search for.
          * @return The constant defined for the given <code>value</code>. Or <code>null</code>, if this value is not
          *         defined by this enumeration.
@@ -209,6 +209,7 @@ public final class ISID {
     }
 
     /** Bit mask to extract the first int out from a long. */
+    @SuppressWarnings("unused")
     private static final long FIRST_LINE_FLAG_MASK = 0xFFFFFFFF00000000L;
 
     /** Bit flag mask to get the field <code>A</code> in this ISID. */
@@ -247,7 +248,7 @@ public final class ISID {
 
     /**
      * This constructor creates a new ISID object with the given settings.
-     * 
+     *
      * @param initT The new T-Value.
      * @param initA The new A-Value.
      * @param initB The new B-Value.
@@ -266,7 +267,7 @@ public final class ISID {
     /**
      * This method creates an Initiator Session ID of the <code>Random</code> format defined in the iSCSI Standard
      * (RFC3720).
-     * 
+     *
      * @param seed The initialization seed for random generator.
      * @return A instance of an <code>ISID</code>.
      */
@@ -285,7 +286,7 @@ public final class ISID {
 
     /**
      * Serializes this ISID object ot its byte representation.
-     * 
+     *
      * @return The byte representation of this ISID object.
      * @throws InternetSCSIException If any violation of the iSCSI-Standard emerge.
      */
@@ -300,7 +301,7 @@ public final class ISID {
         firstLine |= a << Constants.THREE_BYTES_SHIFT;
         firstLine &= 0x00ffffff;
         firstLine |= t.value() << T_FIELD_SHIFT;
-        
+
         isid = Utils.getUnsignedLong(firstLine) << Constants.FOUR_BYTES_SHIFT;
         isid |= Utils.getUnsignedLong(d) << Constants.TWO_BYTES_SHIFT;
 
@@ -309,13 +310,13 @@ public final class ISID {
 
     /**
      * Parses a given ISID in this ISID obejct.
-     * 
+     *
      * @param isid The byte representation of a ISID to parse.
      * @throws InternetSCSIException If any violation of the iSCSI-Standard emerge.
      */
     final void deserialize ( long isid) throws InternetSCSIException {
         int line = (int) (isid >>> Constants.FOUR_BYTES_SHIFT);
-        
+
         t = Format.valueOf((byte) (line  >>> T_FIELD_SHIFT));
         a = (byte) ((line & A_FIELD_FLAG_MASK) >>> Constants.THREE_BYTES_SHIFT);
         b = (short) ((line & Constants.MIDDLE_TWO_BYTES_SHIFT) >>> Constants.ONE_BYTE_SHIFT);
@@ -332,9 +333,10 @@ public final class ISID {
 
     /**
      * Creates a string with all fields of this ISID object.
-     * 
+     *
      * @return The string representation.
      */
+    @Override
     public final String toString () {
 
         final StringBuilder sb = new StringBuilder(Constants.LOG_INITIAL_SIZE);
@@ -351,7 +353,7 @@ public final class ISID {
 
     /**
      * This method compares a given ISID object with this object for value equality.
-     * 
+     *
      * @param isid The given ISID object to check.
      * @return <code>True</code>, if the values of the two ISID objects are equal. Else <code>false</code>.
      */
@@ -408,7 +410,7 @@ public final class ISID {
 
     /**
      * Returns the value of the field <code>A</code>.
-     * 
+     *
      * @return The value of the field <code>A</code>.
      */
     public final byte getA () {
@@ -418,7 +420,7 @@ public final class ISID {
 
     /**
      * Returns the value of the field <code>B</code>.
-     * 
+     *
      * @return The value of the field <code>B</code>.
      */
     public final short getB () {
@@ -428,7 +430,7 @@ public final class ISID {
 
     /**
      * Returns the value of the field <code>C</code>.
-     * 
+     *
      * @return The value of the field <code>C</code>.
      */
     public final byte getC () {
@@ -438,7 +440,7 @@ public final class ISID {
 
     /**
      * Returns the value of the field <code>D</code>.
-     * 
+     *
      * @return The value of the field <code>D</code>.
      */
     public final short getD () {
@@ -448,7 +450,7 @@ public final class ISID {
 
     /**
      * Returns the value of the field <code>T</code>.
-     * 
+     *
      * @return The value of the field <code>T</code>.
      */
     public final Format getT () {
@@ -461,7 +463,7 @@ public final class ISID {
 
     /**
      * This method checks, if all fields are valid. In these cases an exception will be thrown.
-     * 
+     *
      * @throws InternetSCSIException If the integrity is violated.
      */
     protected final void checkIntegrity () throws InternetSCSIException {

--- a/bundles/commons/src/main/java/org/jscsi/parser/tmf/TaskManagementFunctionResponseParser.java
+++ b/bundles/commons/src/main/java/org/jscsi/parser/tmf/TaskManagementFunctionResponseParser.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2012, University of Konstanz, Distributed Systems Group All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
  * following conditions are met: * Redistributions of source code must retain the above copyright notice, this list of
  * conditions and the following disclaimer. * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation and/or other materials provided with the
  * distribution. * Neither the name of the University of Konstanz nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
@@ -28,7 +28,6 @@ import org.jscsi.parser.Constants;
 import org.jscsi.parser.ProtocolDataUnit;
 import org.jscsi.parser.TargetMessageParser;
 import org.jscsi.parser.datasegment.DataSegmentFactory.DataSegmentFormat;
-import org.jscsi.parser.logout.LogoutResponse;
 import org.jscsi.utils.Utils;
 
 
@@ -63,14 +62,14 @@ import org.jscsi.utils.Utils;
  * <p>
  * <h4>TotalAHSLength and DataSegmentLength</h4> For this PDU TotalAHSLength and DataSegmentLength MUST be
  * <code>0</code>.
- * 
+ *
  * @author Volker Wildi
  */
 public final class TaskManagementFunctionResponseParser extends TargetMessageParser {
 
     /**
      * This enumeration defines all valid response code, which are defined in the iSCSI Standard (RFC 3720).
-     * 
+     *
      * @author Volker Wildi
      */
     public static enum ResponseCode {
@@ -110,7 +109,7 @@ public final class TaskManagementFunctionResponseParser extends TargetMessagePar
 
         /**
          * Returns the value of this enumeration.
-         * 
+         *
          * @return The value of this enumeration.
          */
         public final byte value () {
@@ -120,7 +119,7 @@ public final class TaskManagementFunctionResponseParser extends TargetMessagePar
 
         /**
          * Returns the constant defined for the given <code>value</code>.
-         * 
+         *
          * @param value The value to search for.
          * @return The constant defined for the given <code>value</code>. Or <code>null</code>, if this value is not
          *         defined by this enumeration.
@@ -142,7 +141,7 @@ public final class TaskManagementFunctionResponseParser extends TargetMessagePar
 
     /**
      * Default constructor, creates a new, empty <code>TaskManagementFunctionResponseParser</code> object.
-     * 
+     *
      * @param initProtocolDataUnit The reference <code>ProtocolDataUnit</code> instance, which contains this
      *            <code>TaskManagementFunctionResponseParser</code> subclass object.
      */
@@ -260,7 +259,7 @@ public final class TaskManagementFunctionResponseParser extends TargetMessagePar
      * field in the Task Management function request is outside the valid CmdSN window, then targets must return the
      * "Task does not exist" response.</li>
      * </ol>
-     * 
+     *
      * @return The response code of this <code>TaskManagementFunctionResponseParser</code> object.
      */
     public final ResponseCode getResponse () {

--- a/bundles/commons/src/main/java/org/jscsi/utils/SerialArithmeticNumber.java
+++ b/bundles/commons/src/main/java/org/jscsi/utils/SerialArithmeticNumber.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2012, University of Konstanz, Distributed Systems Group All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
  * following conditions are met: * Redistributions of source code must retain the above copyright notice, this list of
  * conditions and the following disclaimer. * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation and/or other materials provided with the
  * distribution. * Neither the name of the University of Konstanz nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
@@ -23,7 +23,7 @@ package org.jscsi.utils;
  * <p/>
  * This class encapsulate the behavior of how to compare and increment a number in Serial Number Arithmetic, which is
  * defined in [RFC1982].
- * 
+ *
  * @author Volker Wildi, University of Konstanz
  */
 public final class SerialArithmeticNumber implements Comparable<Integer> {
@@ -57,7 +57,7 @@ public final class SerialArithmeticNumber implements Comparable<Integer> {
     /**
      * Constructor to create a new <code>SerialArithmeticNumber</code> instance, which is initialized to
      * <code>startValue</code>.
-     * 
+     *
      * @param startValue The start value.
      */
     public SerialArithmeticNumber (final int startValue) {
@@ -72,17 +72,17 @@ public final class SerialArithmeticNumber implements Comparable<Integer> {
 
     /**
      * Same as the <code>compareTo</code> method only with the exception of another parameter type.
-     * 
+     *
      * @param anotherSerialNumber The number to compare with.
      * @return a negative integer, zero, or a positive integer as this <code>SerialArithmeticNumber</code> is less than,
      *         equal to, or greater than the given number.
      */
     public final int compareTo (final int anotherSerialNumber) {
-
-        return compareTo(new Integer(anotherSerialNumber));
+        return compareTo(anotherSerialNumber);
     }
 
     /** {@inheritDoc} */
+    @Override
     public final synchronized int compareTo (final Integer anotherSerialNumber) {
 
         long diff = serialNumber - Utils.getUnsignedLong(anotherSerialNumber.intValue());
@@ -99,7 +99,7 @@ public final class SerialArithmeticNumber implements Comparable<Integer> {
 
     /**
      * Returns the current value of this <code>SerialArithmeticNumber</code> instance.
-     * 
+     *
      * @return The current value of this <code>SerialArithmeticNumber</code> instance.
      */
     public final synchronized int getValue () {
@@ -121,7 +121,7 @@ public final class SerialArithmeticNumber implements Comparable<Integer> {
 
     /**
      * Updates the value of this <code>SerialArithmeticNumber</code> instance to the given one.
-     * 
+     *
      * @param newValue The new value.
      */
     public final synchronized void setValue (final int newValue) {

--- a/bundles/initiator/src/main/java/org/jscsi/initiator/Configuration.java
+++ b/bundles/initiator/src/main/java/org/jscsi/initiator/Configuration.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2012, University of Konstanz, Distributed Systems Group All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
  * following conditions are met: * Redistributions of source code must retain the above copyright notice, this list of
  * conditions and the following disclaimer. * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation and/or other materials provided with the
  * distribution. * Neither the name of the University of Konstanz nor the names of its contributors may be used to
  * endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
@@ -61,7 +61,7 @@ import org.xml.sax.SAXException;
  * <p>
  * This class stores all informations, which are set during an iSCSI Session, Connection or are set as the default
  * values. Therefore, this class was implemented as a Singleton Pattern.
- * 
+ *
  * @author Volker Wildi, University of Konstanz
  */
 public final class Configuration {
@@ -164,7 +164,7 @@ public final class Configuration {
     /**
      * Creates a instance of a <code>Configuration</code> object, which is initialized with the settings from the
      * system-wide configuration file.
-     * 
+     *
      * @return A <code>Configuration</code> instance with all settings.
      * @throws ConfigurationException If this operation is supported but failed for some reason.
      */
@@ -176,12 +176,12 @@ public final class Configuration {
     /**
      * Creates a instance of a <code>Configuration</code> object, which is initialized with the settings from the
      * system-wide configuration file.
-     * 
+     *
      * @param configSchemaFileName The file name of the schema to check the configuration file against.s
      * @param configFileName The file name of the configuration file to use.
      * @return A <code>Configuration</code> instance with all settings.
      * @throws ConfigurationException If this operation is supported but failed for some reason.
-     * 
+     *
      */
     public static final Configuration create (final File configSchemaFileName, final File configFileName) throws ConfigurationException {
 
@@ -195,7 +195,7 @@ public final class Configuration {
 
     /**
      * Returns the value of a single parameter, instead of all values.
-     * 
+     *
      * @param targetName Name of the iSCSI Target to connect.
      * @param connectionID The ID of the connection to retrieve.
      * @param textKey The name of the parameter.
@@ -225,10 +225,7 @@ public final class Configuration {
         final SettingEntry se;
         synchronized (globalConfig) {
             se = globalConfig.get(textKey);
-
-            synchronized (se) {
-                if (se != null) { return se.getValue(); }
-            }
+            if (se != null) { return se.getValue(); }
         }
 
         throw new OperationalTextKeyException("No OperationalTextKey entry found for key: " + textKey.value());
@@ -237,7 +234,7 @@ public final class Configuration {
     /**
      * Unifies all parameters (in the right precedence) and returns one <code>SettingsMap</code>. Right order means:
      * default, then the session-wide, and finally the connection-wide valid parameters.
-     * 
+     *
      * @param targetName Name of the iSCSI Target to connect.
      * @param connectionID The ID of the connection to retrieve.
      * @return All unified parameters in one single <code>SettingsMap</code>.
@@ -273,7 +270,7 @@ public final class Configuration {
 
     /**
      * Returns the value of a single parameter. It can only return session and global parameters.
-     * 
+     *
      * @param targetName Name of the iSCSI Target to connect.
      * @param textKey The name of the parameter.
      * @return The value of the given parameter.
@@ -287,7 +284,7 @@ public final class Configuration {
 
     /**
      * Returns the <code>InetAddress</code> instance of the connected iSCSI Target.
-     * 
+     *
      * @param targetName The name of the iSCSI Target.
      * @return The <code>InetAddress</code> instance of the requested iSCSI Target.
      * @throws NoSuchSessionException if a session with this target name is not open.
@@ -303,7 +300,7 @@ public final class Configuration {
 
     /**
      * Updates the stored settings of a connection with these values from the response of the iSCSI Target.
-     * 
+     *
      * @param targetName The name of the iSCSI Target.
      * @param connectionID The ID of the connection within this iSCSI Target.
      * @param response The response settings.
@@ -314,10 +311,9 @@ public final class Configuration {
         final SessionConfiguration sc;
         synchronized (sessionConfigs) {
             sc = sessionConfigs.get(targetName);
+            if (sc == null) { throw new NoSuchSessionException("A session with the ID '" + targetName + "' does not exist."); }
 
             synchronized (sc) {
-                if (sc == null) { throw new NoSuchSessionException("A session with the ID '" + targetName + "' does not exist."); }
-
                 synchronized (response) {
                     SettingEntry se;
                     for (Map.Entry<OperationalTextKey , String> e : response.entrySet()) {
@@ -350,7 +346,7 @@ public final class Configuration {
 
     /**
      * Reads the given configuration file in memory and creates a DOM representation.
-     * 
+     *
      * @throws SAXException If this operation is supported but failed for some reason.
      * @throws ParserConfigurationException If a <code>DocumentBuilder</code> cannot be created which satisfies the
      *             configuration requested.
@@ -386,7 +382,7 @@ public final class Configuration {
 
     /**
      * Parses all settings form the main configuration file.
-     * 
+     *
      * @param root The root element of the configuration.
      */
     private final void parseSettings (final Element root) {
@@ -400,7 +396,7 @@ public final class Configuration {
 
     /**
      * Parses all global settings form the main configuration file.
-     * 
+     *
      * @param root The root element of the configuration.
      */
     private final void parseGlobalSettings (final Element root) {
@@ -438,7 +434,7 @@ public final class Configuration {
 
     /**
      * Parses all target-specific settings form the main configuration file.
-     * 
+     *
      * @param root The root element of the configuration.
      */
     private final void parseTargetSpecificSettings (final Element root) {
@@ -505,7 +501,7 @@ public final class Configuration {
     /**
      * This class contains a session-wide <code>SettingsMap</code> with one or more connection-specific
      * <code>SettingsMap</code>.
-     * 
+     *
      * @author Volker Wildi
      */
     private final class SessionConfiguration {
@@ -530,7 +526,7 @@ public final class Configuration {
 
         /**
          * Adds a session-wide parameter to this <code>SessionConfiguration</code> object.
-         * 
+         *
          * @param textKey The name of the parameter to add
          * @param textValue The value of the parameter to add.
          */
@@ -542,7 +538,7 @@ public final class Configuration {
         /**
          * Updates the value of the given <code>OperationTextKey</code> of this session with the response key
          * <code>textValue</code> and the result function.
-         * 
+         *
          * @param textKey The <code>OperationalTextKey</code> to update.
          * @param textValue The value of the response.
          * @param resultFunction The <code>IResultFunction</code> instance to use to obtain the result.
@@ -580,7 +576,7 @@ public final class Configuration {
         /**
          * Updates the value of the given <code>OperationTextKey</code> of the given connection within this session with
          * the response key <code>textValue</code> and the result function.
-         * 
+         *
          * @param connectionID The ID of the connection.
          * @param textKey The <code>OperationalTextKey</code> to update.
          * @param textValue The value of the response.
@@ -663,7 +659,7 @@ public final class Configuration {
 
         /**
          * Returns a single setting value of a connection (specified by the ID).
-         * 
+         *
          * @param connectionID The ID of the connection.
          * @param textKey The name of the parameter.
          * @return the value of the given parameter of the connection.
@@ -685,7 +681,7 @@ public final class Configuration {
 
         /**
          * Returns all settings of a connection (specified by the ID).
-         * 
+         *
          * @param connectionID The ID of the connection.
          * @return All session-wide and connection-specific settings of the connection.
          */
@@ -711,7 +707,7 @@ public final class Configuration {
 
         /**
          * Returns the <code>InetAddress</code> of the leading connection of the session.
-         * 
+         *
          * @return An <code>InetAddress</code> instance.
          */
         final InetSocketAddress getInetSocketAddress () {
@@ -721,7 +717,7 @@ public final class Configuration {
 
         /**
          * Sets the <code>InetAddress</code> of the leading connection to the given value.
-         * 
+         *
          * @param newInetAddress The new <code>InetAddress</code> of the leading connection.
          * @param port The new Port of the leading connection;
          * @throws UnknownHostException This exception is thrown, when the host with the given <code>InetAddress</code>

--- a/bundles/target/src/main/java/org/jscsi/target/TargetServer.java
+++ b/bundles/target/src/main/java/org/jscsi/target/TargetServer.java
@@ -28,7 +28,6 @@ import org.jscsi.parser.OperationCode;
 import org.jscsi.parser.ProtocolDataUnit;
 import org.jscsi.parser.login.ISID;
 import org.jscsi.parser.login.LoginRequestParser;
-import org.jscsi.target.connection.Connection;
 import org.jscsi.target.connection.Connection.TargetConnection;
 import org.jscsi.target.connection.TargetSession;
 import org.jscsi.target.scsi.inquiry.DeviceIdentificationVpdPage;
@@ -200,7 +199,7 @@ public class TargetServer implements Callable<Void> {
         target.call();
     }
 
-    private class ConnectionHandler implements Callable {
+    private class ConnectionHandler implements Callable<Void> {
 
         private final TargetConnection targetConnection;
 

--- a/bundles/target/src/main/java/org/jscsi/target/TargetServer.java
+++ b/bundles/target/src/main/java/org/jscsi/target/TargetServer.java
@@ -95,6 +95,7 @@ public class TargetServer implements Callable<Void> {
 
         // read target settings from configuration file
 
+        LOGGER.debug("   target address: " + getConfig().getTargetAddress());
         LOGGER.debug("   port:           " + getConfig().getPort());
         LOGGER.debug("   loading targets.");
         // open the storage medium

--- a/bundles/target/src/main/java/org/jscsi/target/storage/JCloudsStorageModule.java
+++ b/bundles/target/src/main/java/org/jscsi/target/storage/JCloudsStorageModule.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package org.jscsi.target.storage;
 
@@ -45,9 +45,9 @@ import com.google.common.io.ByteStreams;
 /**
  * JClouds-Binding to store blocks as buckets in clouds-backends. This class utilizes caching as well as multithreaded
  * writing to improve performance.
- * 
+ *
  * @author Sebastian Graf, University of Konstanz
- * 
+ *
  */
 @Beta
 public class JCloudsStorageModule implements IStorageModule {
@@ -114,10 +114,10 @@ public class JCloudsStorageModule implements IStorageModule {
     /**
      * Creates a new {@link JCloudsStorageModule} backed by the specified file. If no such file exists, a
      * {@link FileNotFoundException} will be thrown.
-     * 
+     *
      * @param pSizeInBlocks blocksize for this module
      * @param pFile local storage, not used over here
-     * 
+     *
      */
     public JCloudsStorageModule (final long pSizeInBlocks, final File pFile) {
         // number * 512 = size in bytes
@@ -273,7 +273,7 @@ public class JCloudsStorageModule implements IStorageModule {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @throws Exception
      */
     @Override
@@ -328,7 +328,7 @@ public class JCloudsStorageModule implements IStorageModule {
 
     /**
      * Getting credentials for aws from homedir/.credentials
-     * 
+     *
      * @return a two-dimensional String[] with login and password
      */
     private static String[] getCredentials () {
@@ -353,9 +353,9 @@ public class JCloudsStorageModule implements IStorageModule {
 
     /**
      * Single task to write data to the cloud.
-     * 
+     *
      * @author Sebastian Graf, University of Konstanz
-     * 
+     *
      */
     class ReadTask implements Callable<Map.Entry<Integer , byte[]>> {
 
@@ -393,7 +393,7 @@ public class JCloudsStorageModule implements IStorageModule {
                     // + (System.currentTimeMillis() - time) + "\n");
                     // download.flush();
                 } else {
-                    try (InputStream is = blob.getPayload().getInput()) {
+                    try (InputStream is = blob.getPayload().openStream()) {
                        data = ByteStreams.toByteArray(is);
                     }
                     // download.write(Integer.toString(mBucketId) + "," +
@@ -402,7 +402,7 @@ public class JCloudsStorageModule implements IStorageModule {
                     // download.flush();
                     while (data.length < SIZE_PER_BUCKET) {
                         blob = mStore.getBlob(mContainerName, Integer.toString(mBucketId));
-                        try (InputStream is = blob.getPayload().getInput()) {
+                        try (InputStream is = blob.getPayload().openStream()) {
                             data = ByteStreams.toByteArray(is);
                         }
                         // // DEBUG CODE
@@ -444,9 +444,9 @@ public class JCloudsStorageModule implements IStorageModule {
 
     /**
      * Single task to write data to the cloud.
-     * 
+     *
      * @author Sebastian Graf, University of Konstanz
-     * 
+     *
      */
     class WriteTask implements Callable<Integer> {
         /**
@@ -504,6 +504,7 @@ public class JCloudsStorageModule implements IStorageModule {
 
     class ReadFutureCleaner extends Thread {
 
+        @Override
         public void run () {
             while (true) {
                 try {
@@ -520,6 +521,7 @@ public class JCloudsStorageModule implements IStorageModule {
 
     class WriteFutureCleaner extends Thread {
 
+        @Override
         public void run () {
             while (true) {
                 try {

--- a/bundles/target/src/main/resources/jscsi-target.xml
+++ b/bundles/target/src/main/resources/jscsi-target.xml
@@ -52,6 +52,7 @@
 	</TargetList>
 	<GlobalConfig>
 		<AllowSloppyNegotiation>true</AllowSloppyNegotiation>
+		<Address>0.0.0.0</Address>
 		<Port>3260</Port>
 	</GlobalConfig>
 </configuration>

--- a/bundles/target/src/main/resources/jscsi-target.xsd
+++ b/bundles/target/src/main/resources/jscsi-target.xsd
@@ -90,6 +90,8 @@
         <xs:sequence>
             <xs:element name="AllowSloppyNegotiation" type="xs:boolean"
                 default="false" minOccurs="0" maxOccurs="1" />
+            <xs:element name="Address" type="xs:string"
+                minOccurs="0" maxOccurs="1" />
             <xs:element name="Port" type="TargetPortType"
                 default="3260" minOccurs="0" maxOccurs="1" />
         </xs:sequence>


### PR DESCRIPTION
If listening address is not specified when calling Configuration class constructor,
the tag value ```<configuration><GlobalConfig><Address>``` in XML file will be used.
Fix #21 by the way.

**NOTE** "0.0.0.0" means listening on all addresses.
